### PR TITLE
fix(ci): remove invalid 'releases' permission from release-please wor…

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  releases: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
…kflow

GitHub Actions does not have a 'releases' permission - releases are managed through 'contents: write'. This was causing the workflow to fail with "Unexpected value 'releases'" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)