### PR TITLE
feat(ci): add GPG signing for Release Please commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,7 +38,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           release-type: python
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Configure CIFrameworkBot to sign release-please commits with GPG key:
- Import GPG key using crazy-max/ghaction-import-gpg@v6
- Configure git with bot identity and signing key
- Use BOT_PAT for authentication with bot account

Required secrets:
- BOT_GPG_PRIVATE_KEY: CIFrameworkBot's GPG private key
- BOT_PAT: Personal access token for CIFrameworkBot

