### PR TITLE
fix(ci): use inline GPG import instead of external action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,16 +19,9 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.CI_BOT_GPG_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_config_global: true
-
-      - name: Configure Git for CIFrameworkBot
+      - name: Import GPG key and configure Git
         run: |
+          echo "${{ secrets.CI_BOT_GPG_KEY }}" | gpg --batch --import
           git config --global user.name "CIFrameworkBot"
           git config --global user.email "223036950+CIFrameworkBot@users.noreply.github.com"
           git config --global user.signingkey ${{ secrets.CI_BOT_GPG_KEY_ID }}


### PR DESCRIPTION
Replace crazy-max/ghaction-import-gpg@v6 with inline script to avoid action allowlist restrictions. The inline approach:
- Imports GPG key directly via gpg --batch --import
- Configures git with bot identity and signing key
- No external dependencies, full control
