### PR TITLE
fix(ci): update cleanup workflow ref from deleted branch to main

### DIFF
--- a/.github/workflows/cleanup-caller-example.yml
+++ b/.github/workflows/cleanup-caller-example.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   cleanup:
     # Call the centralized reusable workflow
-    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@fix-auto-merge-logic-v2
+    uses: Claire-s-Monster/ci-framework/.github/workflows/cleanup-dev-files.yml@main
     with:
       # Optional: customize cleanup patterns for this repo
       cleanup_patterns: >


### PR DESCRIPTION
The cleanup-caller-example.yml was referencing @fix-auto-merge-logic-v2 which no longer exists. Updated to @main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)