### PR TITLE
fix(ci): add enablement parameter to auto-enable GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - name: Build Documentation
         run: |


### PR DESCRIPTION
Add enablement: true to configure-pages action to automatically enable GitHub Pages if not already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)