### PR TITLE
fix: use positional argument for security scan CLI

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -279,7 +279,7 @@ jobs:
       - name: "Run Security Scans"
         working-directory: ${{ inputs.package-path }}
         run: |
-          python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan --path .
+          python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan .
       - name: "Automated License Compliance Scanning"
         uses: actions/dependency-review-action@v4
         with:


### PR DESCRIPTION
## Summary

Fixes #112 - Security Scan job fails with exit code 2 in v2.3.2

### Problem

The workflow passes `--path .` but the CLI expects a positional argument:

```bash
# This fails with exit code 2
python cli.py scan --path .

# This works
python cli.py scan .
```

### Fix

```diff
- python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan --path .
+ python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan .
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)