### PR TITLE
fix: sync security scan CLI fix to main

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -279,7 +279,7 @@ jobs:
       - name: "Run Security Scans"
         working-directory: ${{ inputs.package-path }}
         run: |
-          python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan --path .
+          python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan .
       - name: "Automated License Compliance Scanning"
         uses: actions/dependency-review-action@v4
         with:


### PR DESCRIPTION
## Summary

Fixes #112 - Security Scan job fails with exit code 2

### Change

```diff
- python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan --path .
+ python $GITHUB_WORKSPACE/ci-framework/framework/security/cli.py scan .
```

The CLI expects a positional argument, not `--path` flag.

---

🤖 Generated with [Claude Code](https://claude.ai/code)