### PR TITLE
feat: add optional PostgreSQL service container support

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -13,6 +13,7 @@
 #        with:
 #          pixi-environment: 'ci'
 #          python-versions: '["3.10", "3.11", "3.12"]'
+#          enable-postgres: true  # optional: adds PostgreSQL service container
 #        secrets: inherit
 #    ```
 #
@@ -122,6 +123,14 @@ on:
         required: false
         type: string
         default: '3.12'
+      # --- Service container inputs ---
+      enable-postgres:
+        description: >-
+          Provision a PostgreSQL 16 service container and set POSTGRES_DSN
+          for integration tests. Only applies to ubuntu runners.
+        required: false
+        type: boolean
+        default: false
     secrets:
       CODECOV_TOKEN:
         description: "Token for uploading coverage reports to Codecov"
@@ -643,6 +652,64 @@ jobs:
         run: |
           pixi run -e ${{ inputs.pixi-environment }} test
 
+  test-postgres:
+    name: "🐘 Test+PG Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: >-
+      inputs.enable-postgres &&
+      (needs.detect-changes.outputs.src == 'true' ||
+       needs.detect-changes.outputs.tests == 'true')
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: ci_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U ci"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(inputs.python-versions) }}
+    env:
+      POSTGRES_DSN: "postgresql://ci:ci@localhost:5432/ci_test"
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Setup Python ${{ matrix.python-version }}"
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: "Setup PIXI Environment"
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.49.0
+          cache: false
+      - name: "Install Dependencies"
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          pixi install -e ${{ inputs.pixi-environment }}
+      - name: "Editable Install (pixi-only)"
+        if: inputs.editable-install
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          if [ ! -f pixi.toml ] && [ ! -f pixi.lock ] && ! grep -q '\[tool\.pixi' pyproject.toml 2>/dev/null; then
+            echo "::error::No pixi.toml or pixi.lock found, and no [tool.pixi] section in pyproject.toml. ci-framework requires pixi-based projects."
+            exit 1
+          fi
+          pixi run -e ${{ inputs.pixi-environment }} pip install -e . --no-deps
+      - name: "Run Test Suite (with PostgreSQL)"
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          pixi run -e ${{ inputs.pixi-environment }} test
+
+
   performance:
     name: "📊 Performance Analysis"
     runs-on: ubuntu-latest
@@ -731,6 +798,7 @@ jobs:
       - secret-scan
       - scorecard
       - test
+      - test-postgres
       - performance
       - build
       - self-heal
@@ -768,6 +836,7 @@ jobs:
             echo "| Job | Status |"
             echo "|-----|--------|"
             echo "| Test | ${{ needs.test.result }} |"
+            echo "| Test+PG | ${{ needs.test-postgres.result }} |"
             echo "| Performance | ${{ needs.performance.result }} |"
             echo "| Build | ${{ needs.build.result }} |"
             echo "| Self-Heal | ${{ needs.self-heal.result }} |"
@@ -790,6 +859,7 @@ jobs:
             "${{ needs.js-dep-audit.result }}" \
             "${{ needs.secret-scan.result }}" \
             "${{ needs.test.result }}" \
+            "${{ needs.test-postgres.result }}" \
             "${{ needs.build.result }}"; do
             if [[ "$result" == "failure" ]]; then
               FAILED=true

--- a/framework/tests/workflows/test_reusable_workflow_lint.py
+++ b/framework/tests/workflows/test_reusable_workflow_lint.py
@@ -366,7 +366,9 @@ class TestCrossFileConsistency:
         old_jobs = {"security", "quality"}
         # Optional service-container jobs only in reusable workflow
         optional_service_jobs = {"test-postgres"}
-        reusable_core = reusable_jobs - multi_lang_jobs - old_jobs - optional_service_jobs
+        reusable_core = (
+            reusable_jobs - multi_lang_jobs - old_jobs - optional_service_jobs
+        )
         standalone_core = standalone_jobs - multi_lang_jobs - old_jobs - {"configure"}
         assert reusable_core == standalone_core, (
             f"Core job mismatch: reusable={sorted(reusable_core)}, standalone={sorted(standalone_core)}"

--- a/framework/tests/workflows/test_reusable_workflow_lint.py
+++ b/framework/tests/workflows/test_reusable_workflow_lint.py
@@ -364,7 +364,9 @@ class TestCrossFileConsistency:
             "js-lint",
         }
         old_jobs = {"security", "quality"}
-        reusable_core = reusable_jobs - multi_lang_jobs - old_jobs
+        # Optional service-container jobs only in reusable workflow
+        optional_service_jobs = {"test-postgres"}
+        reusable_core = reusable_jobs - multi_lang_jobs - old_jobs - optional_service_jobs
         standalone_core = standalone_jobs - multi_lang_jobs - old_jobs - {"configure"}
         assert reusable_core == standalone_core, (
             f"Core job mismatch: reusable={sorted(reusable_core)}, standalone={sorted(standalone_core)}"


### PR DESCRIPTION
## Summary

- Adds `enable-postgres` boolean input to the reusable CI workflow (default: `false`)
- Provisions a PostgreSQL 16 service container with health checks when enabled
- Sets `POSTGRES_DSN` env var so tests can detect and use the database
- Implemented as a separate `test-postgres` job (ubuntu-only) since GitHub Actions `services:` blocks cannot be conditional

Closes #164

## Usage

```yaml
jobs:
  ci:
    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@main
    with:
      enable-postgres: true
    secrets: inherit
```

## Test plan

- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Test with `enable-postgres: false` (default) — `test-postgres` job should be skipped
- [ ] Test with `enable-postgres: true` — PostgreSQL container starts, `POSTGRES_DSN` is set
- [ ] Verify existing `test` job is unaffected
- [ ] Verify summary table includes Test+PG row

🤖 Generated with [Claude Code](https://claude.com/claude-code)