### PR TITLE
fix: release automation token and reusable-ci permissions

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -35,4 +35,7 @@ jobs:
             --auto --squash --delete-branch \
             --repo "${{ github.repository }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # CI_BOT_TOKEN (PAT) required so the merge push triggers
+          # downstream on:push workflows (e.g. release-please).
+          # GITHUB_TOKEN pushes are silently ignored by Actions.
+          GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,7 @@ on:
     - cron: '0 0 * * *'  # Nightly build
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write  # CodeQL/Semgrep/C++ lint SARIF uploads
-  id-token: write          # OpenSSF Scorecard
+permissions: read-all
 
 jobs:
   lint-and-format:
@@ -66,6 +62,9 @@ jobs:
   security-scan:
     name: "🛡️ Security Scan"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # CodeQL SARIF upload
     steps:
       - uses: actions/checkout@v6
       - name: "Set up Pixi"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write  # Required for CodeQL SARIF uploads
+  security-events: write  # CodeQL/Semgrep/C++ lint SARIF uploads
+  id-token: write          # OpenSSF Scorecard
 
 jobs:
   lint-and-format:

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -7,19 +7,20 @@
 #
 # USAGE (recommended — remote call):
 #    ```yaml
-#    permissions:
-#      contents: read
-#      actions: read
-#      security-events: write   # SARIF uploads (CodeQL, Semgrep, C/C++ lint)
-#      id-token: write          # OpenSSF Scorecard
+#    permissions: read-all          # Scorecard-safe top-level
 #
 #    jobs:
 #      ci:
+#        permissions:               # Elevated grants scoped to this job
+#          contents: read
+#          actions: read
+#          security-events: write   # SARIF uploads (CodeQL, Semgrep, C/C++ lint)
+#          id-token: write          # OpenSSF Scorecard
 #        uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@main
 #        with:
 #          pixi-environment: 'ci'
 #          python-versions: '["3.10", "3.11", "3.12"]'
-#          enable-postgres: true  # optional: adds PostgreSQL service container
+#          enable-postgres: true    # optional: adds PostgreSQL service container
 #        secrets: inherit
 #    ```
 #
@@ -154,7 +155,7 @@ on:
 # cap all per-job permissions, breaking security-events and id-token
 # grants needed by SARIF upload and Scorecard jobs.
 #
-# Callers should grant at minimum:
+# Callers should grant at the job level (not top-level, to satisfy Scorecard):
 #   contents: read, actions: read, security-events: write, id-token: write
 
 jobs:

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -16,7 +16,7 @@
 #          actions: read
 #          security-events: write   # SARIF uploads (CodeQL, Semgrep, C/C++ lint)
 #          id-token: write          # OpenSSF Scorecard
-#        uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@main
+#        uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@<sha>  # <version>
 #        with:
 #          pixi-environment: 'ci'
 #          python-versions: '["3.10", "3.11", "3.12"]'

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -7,6 +7,12 @@
 #
 # USAGE (recommended — remote call):
 #    ```yaml
+#    permissions:
+#      contents: read
+#      actions: read
+#      security-events: write   # SARIF uploads (CodeQL, Semgrep, C/C++ lint)
+#      id-token: write          # OpenSSF Scorecard
+#
 #    jobs:
 #      ci:
 #        uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@main
@@ -143,9 +149,13 @@ on:
         description: "Token for Sourcery AI code reviewer"
         required: false
 
-permissions:
-  contents: read
-  actions: read
+# NOTE: No top-level permissions block. For workflow_call, the CALLER
+# controls the GITHUB_TOKEN permissions. A top-level block here would
+# cap all per-job permissions, breaking security-events and id-token
+# grants needed by SARIF upload and Scorecard jobs.
+#
+# Callers should grant at minimum:
+#   contents: read, actions: read, security-events: write, id-token: write
 
 jobs:
   detect-changes:

--- a/.github/workflows/sync-main-to-development.yml
+++ b/.github/workflows/sync-main-to-development.yml
@@ -87,4 +87,7 @@ jobs:
               --auto --merge --repo "${{ github.repository }}" || true
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # CI_BOT_TOKEN (PAT) required so the merge push triggers
+          # downstream on:push workflows. GITHUB_TOKEN pushes are
+          # silently ignored by Actions.
+          GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Use `CI_BOT_TOKEN` in auto-merge-release and sync-main-to-development so merge pushes trigger downstream workflows (fixes v2.9.1 release failure)
- Remove top-level `permissions:` from reusable-ci.yml that was capping per-job grants, breaking consumer CI SARIF uploads
- Add `id-token: write` to ci.yml for OpenSSF Scorecard
- Document required caller permissions in reusable-ci.yml usage comments

## Root Cause

`GITHUB_TOKEN` pushes are silently ignored by GitHub Actions (`on: push` workflows don't fire). The release-please workflow never ran after auto-merge, so no tag/release was created for v2.9.1.

Separately, a top-level `permissions:` block in a `workflow_call` workflow caps all per-job permissions — jobs declaring `security-events: write` were silently denied.

## Test plan

- [ ] CI passes on this PR (validates reusable-ci permissions change)
- [ ] After merge to main, verify release-please creates a new release PR
- [ ] Verify consumer repos can trigger CI with SARIF uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)