### PR TITLE
fix: use CI_BOT_TOKEN in release-please to avoid workflow approval gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,11 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # CI_BOT_TOKEN so the PR is authored by CIFrameworkBot (a repo
+          # collaborator), not github-actions[bot] (outside collaborator).
+          # Avoids "workflows awaiting approval" on public repos and ensures
+          # the merge push triggers downstream on:push workflows.
+          token: ${{ secrets.CI_BOT_TOKEN }}
           release-type: python
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
PRs authored by github-actions[bot] (via GITHUB_TOKEN) require maintainer approval before workflows run on public repos. Switch release-please to CI_BOT_TOKEN so PRs are authored by CIFrameworkBot (a repo collaborator), bypassing the approval gate.