### PR TITLE
fix: release automation tokens and Scorecard-safe permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,11 +31,12 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          # CI_BOT_TOKEN so the PR is authored by CIFrameworkBot (a repo
+          # CI_BOT_TOKEN (PAT) so the PR is authored by CIFrameworkBot (a repo
           # collaborator), not github-actions[bot] (outside collaborator).
           # Avoids "workflows awaiting approval" on public repos and ensures
           # the merge push triggers downstream on:push workflows.
-          token: ${{ secrets.CI_BOT_TOKEN }}
+          # Falls back to GITHUB_TOKEN if CI_BOT_TOKEN is not configured.
+          token: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           release-type: python
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Use `CI_BOT_TOKEN || GITHUB_TOKEN` in auto-merge-release, sync-main-to-development, and release-please so merge pushes trigger downstream workflows and PRs aren't authored by `github-actions[bot]`
- Remove top-level `permissions:` from reusable-ci.yml (was capping per-job grants, breaking consumer SARIF uploads)
- Scope `security-events: write` per-job in ci.yml, set top-level to `read-all` for Scorecard compliance
- Show SHA pinning in reusable-ci.yml usage docs (Scorecard Pinned-Dependencies)
- Add `GITHUB_TOKEN` fallback to release-please token (fixes Bad credentials when `CI_BOT_TOKEN` is not configured)

## Root Causes

1. `GITHUB_TOKEN` pushes don't trigger `on: push` workflows (v2.9.1 release failure)
2. `workflow_call` top-level `permissions:` caps all per-job grants (consumer CI broken)
3. Top-level write permissions flagged by Scorecard Token-Permissions
4. PRs by `github-actions[bot]` require maintainer approval on public repos
5. `CI_BOT_TOKEN` without fallback causes Bad credentials if secret is missing

## Test plan

- [ ] CI passes on this PR
- [ ] After merge to main, release-please creates PR without approval gate
- [ ] Consumer repos can run CI with SARIF uploads and Scorecard

🤖 Generated with [Claude Code](https://claude.com/claude-code)