### PR TITLE
fix: eliminate security-events: write requirement for consumer repos

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,15 +6,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-  pages: write
-  id-token: write
+permissions: read-all
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -14,8 +14,10 @@
 #        permissions:               # Elevated grants scoped to this job
 #          contents: read
 #          actions: read
-#          security-events: write   # SARIF uploads (CodeQL, Semgrep, C/C++ lint)
 #          id-token: write          # OpenSSF Scorecard
+#          # security-events: write — NOT NEEDED when CI_BOT_TOKEN is
+#          # provided (see secrets below).  Omit for clean Scorecard
+#          # Token-Permissions score.
 #        uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@<sha>  # <version>
 #        with:
 #          pixi-environment: 'ci'
@@ -149,14 +151,26 @@ on:
       SOURCERY_TOKEN:
         description: "Token for Sourcery AI code reviewer"
         required: false
+      CI_BOT_TOKEN:
+        description: >-
+          PAT with security_events scope for SARIF uploads (CodeQL,
+          Semgrep, Scorecard).  When provided, callers do NOT need
+          security-events: write on GITHUB_TOKEN, keeping Scorecard
+          Token-Permissions clean.  Falls back to github.token.
+        required: false
 
 # NOTE: No top-level permissions block. For workflow_call, the CALLER
 # controls the GITHUB_TOKEN permissions. A top-level block here would
-# cap all per-job permissions, breaking security-events and id-token
-# grants needed by SARIF upload and Scorecard jobs.
+# cap all per-job permissions, breaking id-token grants needed by
+# Scorecard jobs.
 #
 # Callers should grant at the job level (not top-level, to satisfy Scorecard):
-#   contents: read, actions: read, security-events: write, id-token: write
+#   contents: read, actions: read, id-token: write
+#
+# SARIF uploads (CodeQL, Semgrep, Scorecard) use CI_BOT_TOKEN when
+# available, falling back to github.token.  This avoids needing
+# security-events: write on GITHUB_TOKEN.  All upload steps use
+# continue-on-error as a safety net.
 
 jobs:
   detect-changes:
@@ -405,6 +419,7 @@ jobs:
         with:
           sarif_file: cpp-linter.sarif
           category: cpp-linter
+          token: ${{ secrets.CI_BOT_TOKEN || github.token }}
         continue-on-error: true
       - name: Fail on lint
         if: inputs.fail-on-lint && steps.linter.outputs.checks-failed > 0
@@ -550,6 +565,7 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: semgrep
+          token: ${{ secrets.CI_BOT_TOKEN || github.token }}
         continue-on-error: true
       - name: Fail on SAST findings
         if: inputs.fail-on-sast && steps.semgrep.outcome == 'failure'
@@ -575,8 +591,16 @@ jobs:
       - uses: github/codeql-action/autobuild@v4
       - uses: github/codeql-action/analyze@v4
         with:
-          upload: true
+          upload: false
+          output: codeql-results
           category: codeql-${{ matrix.language }}
+      - name: Upload CodeQL SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: codeql-results/${{ matrix.language }}.sarif
+          category: codeql-${{ matrix.language }}
+          token: ${{ secrets.CI_BOT_TOKEN || github.token }}
+        continue-on-error: true
 
   secret-scan:
     name: "🔑 Secret Scanning"
@@ -621,6 +645,7 @@ jobs:
         with:
           sarif_file: scorecard.sarif
           category: scorecard
+          token: ${{ secrets.CI_BOT_TOKEN || github.token }}
         continue-on-error: true
 
   # ============================================================================

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -51,9 +51,10 @@ on:
         type: string
         default: '3.12'
 
-permissions:
-  contents: read
-  security-events: write
+# NOTE: No top-level permissions block. For workflow_call the CALLER
+# controls GITHUB_TOKEN permissions.  Each job below declares its own
+# least-privilege set; SARIF uploads use continue-on-error so the
+# pipeline succeeds even when security-events: write is not granted.
 
 jobs:
   detect-languages:

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -14,10 +14,13 @@
 #      security:
 #        uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@main
 #        permissions:
-#          security-events: write
 #          contents: read
 #          actions: read
 #          id-token: write
+#          # security-events: write — NOT NEEDED when CI_BOT_TOKEN is
+#          # provided via secrets: inherit.  Omit for clean Scorecard
+#          # Token-Permissions score.
+#        secrets: inherit           # passes CI_BOT_TOKEN for SARIF uploads
 #    ```
 #
 # See docs/security-scanning.md for full documentation.
@@ -52,12 +55,19 @@ on:
         required: false
         type: boolean
         default: true
+    secrets:
+      CI_BOT_TOKEN:
+        description: >-
+          PAT with security_events scope for SARIF uploads.  When
+          provided, callers do NOT need security-events: write on
+          GITHUB_TOKEN, keeping Scorecard Token-Permissions clean.
+          Falls back to github.token.
+        required: false
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+# NOTE: No top-level permissions block. For workflow_call the CALLER
+# controls GITHUB_TOKEN permissions, and a top-level block here would
+# cap all jobs (preventing security-events: write even when the caller
+# grants it).  Each job below declares its own least-privilege set.
 
 jobs:
   detect-languages:
@@ -225,6 +235,7 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: semgrep
+          token: ${{ secrets.CI_BOT_TOKEN || github.token }}
         continue-on-error: true
       - name: Fail on SAST findings
         if: inputs.fail-on-sast && steps.semgrep.outcome == 'failure'
@@ -237,6 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -249,8 +261,16 @@ jobs:
       - uses: github/codeql-action/autobuild@v4
       - uses: github/codeql-action/analyze@v4
         with:
-          upload: true
+          upload: false
+          output: codeql-results
           category: codeql-${{ matrix.language }}
+      - name: Upload CodeQL SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: codeql-results/${{ matrix.language }}.sarif
+          category: codeql-${{ matrix.language }}
+          token: ${{ secrets.CI_BOT_TOKEN || github.token }}
+        continue-on-error: true
 
   secret-scan:
     name: "🔑 Secret Scanning"
@@ -295,6 +315,7 @@ jobs:
         with:
           sarif_file: scorecard.sarif
           category: scorecard
+          token: ${{ secrets.CI_BOT_TOKEN || github.token }}
         continue-on-error: true
 
   security-summary:

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -42,10 +42,7 @@ name: Standalone Package CI
 on:
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: read-all
 
 # ============================================================================
 # STEP-LEVEL CONFIGURATION — Used in step run/with blocks
@@ -261,6 +258,9 @@ jobs:
   security:
     name: "🛡️ Security Scan"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # CodeQL SARIF upload
     needs: detect-changes
     if: needs.detect-changes.outputs.security == 'true'
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,7 @@ pixi.lock
 .aider*
 .serena/
 GEMINI.md
+docs/superpowers/
 
 # Development directories
 dev-outputs/

--- a/docs/best-practices/security-scanning-patterns.md
+++ b/docs/best-practices/security-scanning-patterns.md
@@ -283,7 +283,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     permissions:
-      security-events: write  # Required for SARIF upload
+      security-events: write  # optional — required only for SARIF upload to Security tab
     steps:
       - uses: actions/checkout@v4
       

--- a/docs/examples/interactive/troubleshooting-guide.md
+++ b/docs/examples/interactive/troubleshooting-guide.md
@@ -524,7 +524,7 @@ pixi run lint
    # Add required permissions
    permissions:
      contents: read
-     security-events: write  # For SARIF uploads
+     # security-events: write  # optional — for SARIF uploads
      actions: read          # For artifact access
    ```
 
@@ -855,7 +855,7 @@ jobs:
    # Add required permissions to workflow
    permissions:
      contents: read           # Read repository contents
-     security-events: write   # Upload SARIF reports
+     # security-events: write # optional — upload SARIF reports (omit for Scorecard compliance)
      actions: read           # Access action artifacts
      issues: write           # Comment on PRs
      pull-requests: write    # Update PR status
@@ -942,9 +942,9 @@ env:
    
    **🛠️ Solution:**
    ```yaml
-   # Required permissions for SARIF upload
+   # Permissions for SARIF upload (optional)
    permissions:
-     security-events: write  # Critical for SARIF
+     security-events: write  # optional — only needed for SARIF upload
      contents: read
    
    # Upload SARIF results
@@ -1036,7 +1036,8 @@ env:
 # Balanced security configuration
 [tool.ci-framework.security-scan]
 default_level = "medium"
-enable_sarif = true
+enable_sarif = true  # optional — enables SARIF upload for Security tab
+# omit enable_sarif for clean Scorecard Token-Permissions score
 
 # Tool-specific settings
 [tool.ci-framework.security-scan.bandit]

--- a/docs/multi-language-ci.md
+++ b/docs/multi-language-ci.md
@@ -158,7 +158,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       id-token: write
       checks: write
     secrets: inherit
@@ -166,7 +166,7 @@ jobs:
 
 - `contents: write` — Create/update releases and badges
 - `pull-requests: write` — Post coverage reports to PRs
-- `security-events: write` — Upload SARIF to Security tab
+- `security-events: write` (OPTIONAL) — Upload SARIF to Security tab. Omit for clean Scorecard Token-Permissions score.
 - `id-token: write` — For CodeQL and PyPI token exchange
 - `checks: write` — Annotations in workflow summary
 - `secrets: inherit` — Access repository secrets for publishing
@@ -188,7 +188,7 @@ jobs:
   security:
     uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@main
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write
@@ -300,7 +300,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       id-token: write
       checks: write
     secrets: inherit

--- a/docs/quality-checks.md
+++ b/docs/quality-checks.md
@@ -207,7 +207,7 @@ jobs:
   security:
     uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@main
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -17,17 +17,17 @@ jobs:
   security:
     uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@main
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write
 ```
 
 **Required permissions:**
-- `security-events: write` — Upload SARIF reports to GitHub Security tab
 - `contents: read` — Read source code
 - `actions: read` — Read workflow metadata
 - `id-token: write` — For CodeQL authentication
+- `security-events: write` (OPTIONAL) — Upload SARIF reports to GitHub Security tab. Omit for clean Scorecard Token-Permissions score.
 
 All inputs are optional. The workflow will auto-detect your languages and use sensible defaults.
 
@@ -93,7 +93,7 @@ jobs:
   security:
     uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@main
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write
@@ -110,7 +110,7 @@ jobs:
     with:
       fail-on-sast: true
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write
@@ -127,7 +127,7 @@ jobs:
     with:
       languages: 'python,rust'
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write
@@ -146,7 +146,7 @@ jobs:
       fail-on-secrets: false
       fail-on-sast: false
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write
@@ -163,7 +163,7 @@ jobs:
     with:
       scorecard: false
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write
@@ -218,7 +218,7 @@ jobs:
   security:
     uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-security.yml@main
     permissions:
-      security-events: write
+      # security-events: write  # optional — enables SARIF upload to Security tab
       contents: read
       actions: read
       id-token: write


### PR DESCRIPTION
## Summary

- **CI_BOT_TOKEN bypass**: All `upload-sarif` steps now use `CI_BOT_TOKEN` (PAT with `security_events` scope) via `secrets: inherit`, falling back to `github.token`. Consumers no longer need `security-events: write` on GITHUB_TOKEN.
- **Graceful degradation**: CodeQL analyze split into `upload: false` + separate `upload-sarif` with `continue-on-error: true`. Pipeline succeeds regardless of SARIF permission.
- **Scorecard-safe permissions**: `release-please.yml`, `standalone-ci.yml` use `permissions: read-all` top-level with job-scoped grants. Removed top-level permissions blocks from `reusable-quality.yml` and `reusable-security.yml`.
- **Docs updated**: All 17 references to `security-events: write` across 5 doc files marked as optional.

## Root cause

Scorecard Token-Permissions cannot see through `workflow_call` boundaries — it flags `security-events: write` on callers without recognizing the CodeQL/SARIF justification in the called workflow.

## Consumer migration

1. Add `CI_BOT_TOKEN` repo secret (PAT with `security_events` scope)
2. Remove `security-events: write` from caller permissions
3. Keep `secrets: inherit` (already standard)

## Test plan

- [ ] CI passes on this PR
- [ ] Consumer repo removes `security-events: write`, Scorecard Token-Permissions score improves
- [ ] SARIF uploads still appear in Security tab when `CI_BOT_TOKEN` is configured
- [ ] Pipeline succeeds gracefully when neither `security-events: write` nor `CI_BOT_TOKEN` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>