### PR TITLE
fix: remove internal security-events: write from reusable workflows

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -399,7 +399,6 @@ jobs:
     if: needs.detect-changes.outputs.c_cpp == 'true'
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       contents: read
     steps:
       - uses: actions/checkout@v6
@@ -547,7 +546,6 @@ jobs:
     if: needs.detect-changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       contents: read
     container:
       image: semgrep/semgrep
@@ -577,7 +575,6 @@ jobs:
     if: needs.detect-changes.outputs.has_codeql == 'true'
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       contents: read
     strategy:
       fail-fast: false
@@ -627,7 +624,6 @@ jobs:
     if: inputs.scorecard
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       id-token: write
       actions: read
       contents: read

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -65,9 +65,9 @@ on:
         required: false
 
 # NOTE: No top-level permissions block. For workflow_call the CALLER
-# controls GITHUB_TOKEN permissions, and a top-level block here would
-# cap all jobs (preventing security-events: write even when the caller
-# grants it).  Each job below declares its own least-privilege set.
+# controls GITHUB_TOKEN permissions.  Each job below declares its own
+# least-privilege set.  SARIF uploads use CI_BOT_TOKEN (PAT) so
+# callers never need security-events: write on GITHUB_TOKEN.
 
 jobs:
   detect-languages:
@@ -247,7 +247,6 @@ jobs:
     if: needs.detect-languages.outputs.has_codeql == 'true'
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       contents: read
     strategy:
       fail-fast: false
@@ -297,7 +296,6 @@ jobs:
     if: inputs.scorecard
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       id-token: write
       actions: read
       contents: read


### PR DESCRIPTION
## Summary

v2.9.3 still caused `startup_failure` for consumers who removed `security-events: write` because GitHub Actions validates reusable workflow job permissions at **parse time**. If a called workflow job declares `security-events: write`, the caller must grant it or the job fails before any steps run.

- Removed `security-events: write` from 6 job-level permissions blocks across `reusable-ci.yml` (c-cpp-lint, sast-semgrep, sast-codeql, scorecard) and `reusable-security.yml` (sast-codeql, scorecard)
- SARIF uploads now rely entirely on `CI_BOT_TOKEN` PAT passed via `secrets: inherit`
- Callers never need `security-events: write` on GITHUB_TOKEN

## Root cause

GitHub Actions reusable workflow permissions are validated at parse time, not runtime. `continue-on-error` and CI_BOT_TOKEN fallback cannot help if the permission is still declared in the job's permissions block.

## Test plan

- [ ] CI passes on this PR
- [ ] Consumer repo without `security-events: write` no longer gets `startup_failure`
- [ ] SARIF uploads work via `CI_BOT_TOKEN` when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)