### PR TITLE
fix(ci): drop emoji prefix from Security Scan job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           pixi run -e quality typecheck || echo "Type check completed with issues"
 
   security-scan:
-    name: "🛡️ Security Scan"
+    name: "Security Scan"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -256,7 +256,7 @@ jobs:
   # Job 5: Security Scan
   # ==========================================================================
   security:
-    name: "🛡️ Security Scan"
+    name: "Security Scan"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Drop the shield-emoji prefix on the `Security Scan` job-level `name:` field in `ci.yml` and `standalone-ci.yml` so the posted check name matches the `development` ruleset requirement.

## Root cause

The `development` ruleset has a required status check `Security Scan` (no emoji). The job was emitting `🛡️ Security Scan` (with shield emoji prefix). GitHub matches required checks by **exact string**, so the emoji-prefixed name never satisfied the rule — every Dependabot PR (#202–#207) stayed in `mergeable=True, merge_state=blocked` despite all checks reporting green.

Diagnosis trail:
- `gh api repos/Claire-s-Monster/ci-framework/rules/branches/development` showed `{"context":"Security Scan","integration_id":57789}` (after also fixing a separate `integration_id` pin on `CodeQL` via UI: both checks switched to "Any source")
- PR #207 check rollup showed `✅ 🛡️ Security Scan` — success, but under a name the ruleset doesn't recognize

## Changes

- `.github/workflows/ci.yml:63` — job `security-scan:` `name` changed from `"🛡️ Security Scan"` to `"Security Scan"`
- `.github/workflows/standalone-ci.yml:259` — job `security:` `name` changed from `"🛡️ Security Scan"` to `"Security Scan"`

No other emoji-prefixed job names touched (those don't gate the ruleset).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge to `development`, close+reopen PR #207 (or rebase it) so CI re-runs under the new job name
- [ ] Verify PR #207 transitions from `merge_state: blocked` → `clean` and auto-merge fires
- [ ] Next Dependabot PR opens → auto-merges without intervention

## Follow-up

Consider establishing a convention: **no emojis on `name:` fields for any job listed as a required status check**. Emojis on cosmetic-only jobs are fine. This is the second recurrence of this footgun in 10 minutes — the first being the ruleset's earlier emoji-stripping during the UI edit.