### PR TITLE
fix(ci): gate reusable-ci.yml CodeQL behind `codeql` input to prevent…

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -111,6 +111,11 @@ on:
         required: false
         type: boolean
         default: true
+      codeql:
+        description: "Run CodeQL SAST in this workflow. Default false: CodeQL is owned by reusable-security.yml so the two workflows don't upload the same codeql-<lang> category and produce a neutral CodeQL check (issue #215). Enable only when consuming reusable-ci.yml WITHOUT reusable-security.yml."
+        required: false
+        type: boolean
+        default: false
       # --- Quality inputs ---
       fail-on-lint:
         description: "Fail on lint violations"
@@ -580,7 +585,10 @@ jobs:
   sast-codeql:
     name: "🔬 CodeQL Analysis"
     needs: detect-changes
-    if: needs.detect-changes.outputs.has_codeql == 'true'
+    # Gated off by default to avoid colliding with reusable-security.yml on the
+    # codeql-<lang> SARIF category (issue #215). Opt in via the `codeql` input
+    # when using this workflow standalone (no reusable-security.yml).
+    if: inputs.codeql && needs.detect-changes.outputs.has_codeql == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
… duplicate codeql-python upload (#215)

reusable-ci.yml and reusable-security.yml both ran github/codeql-action for Python and uploaded SARIF under the identical category `codeql-python` on the same ref. GitHub's Code Scanning app dedups per-category, so the aggregate CodeQL check-run resolved to `neutral` (red on consumer PRs, non-blocking) and per-PR CodeQL runtime was doubled.

Add a `codeql` workflow_call input (default false) and gate the sast-codeql job on it. CodeQL for Python is now owned solely by reusable-security.yml by default; consumers using reusable-ci.yml standalone can opt back in with `codeql: true`. The CI summary job is `if: always()` and the job was already skippable, so no dependents break.

Refs #215