### PR TITLE
fix(ci): add codeql-languages allowlist + harden c-cpp CodeQL leg (#227)

### DIFF
--- a/.github/actions/setup-codeql-matrix/action.yml
+++ b/.github/actions/setup-codeql-matrix/action.yml
@@ -1,0 +1,74 @@
+name: 'Setup CodeQL Matrix'
+description: >-
+  Build the CodeQL language matrix from an explicit allowlist
+  (codeql-languages) or, when empty, from autodetected language flags.
+  Emits `matrix` (JSON array) and `has_codeql` for a downstream
+  sast-codeql job. Shared by reusable-ci.yml and reusable-security.yml
+  (issue #227).
+
+inputs:
+  codeql-languages:
+    description: >-
+      Comma-separated CodeQL language allowlist (python, c-cpp,
+      javascript-typescript). When non-empty, overrides autodetection.
+    required: false
+    default: ''
+  python:
+    description: 'Autodetect flag: python sources present ("true"/"false").'
+    required: false
+    default: 'false'
+  c_cpp:
+    description: 'Autodetect flag: C/C++ sources present ("true"/"false").'
+    required: false
+    default: 'false'
+  js_ts:
+    description: 'Autodetect flag: JS/TS sources present ("true"/"false").'
+    required: false
+    default: 'false'
+
+outputs:
+  matrix:
+    description: 'JSON array of CodeQL languages for the analysis matrix.'
+    value: ${{ steps.build.outputs.matrix }}
+  has_codeql:
+    description: 'Whether any CodeQL language is present ("true"/"false").'
+    value: ${{ steps.build.outputs.has_codeql }}
+
+runs:
+  using: composite
+  steps:
+    - id: build
+      shell: bash
+      env:
+        # Map inputs to env vars instead of inlining ${{ }} expressions into
+        # the shell — avoids GitHub Actions expression/shell injection.
+        CODEQL_LANGUAGES: ${{ inputs.codeql-languages }}
+        DETECT_PYTHON: ${{ inputs.python }}
+        DETECT_C_CPP: ${{ inputs.c_cpp }}
+        DETECT_JS_TS: ${{ inputs.js_ts }}
+      run: |
+        langs=()
+        if [ -n "$CODEQL_LANGUAGES" ]; then
+          # Explicit allowlist overrides autodetection for CodeQL only (issue #227)
+          IFS=',' read -ra requested <<< "$CODEQL_LANGUAGES"
+          for l in "${requested[@]}"; do
+            l="$(echo "$l" | tr -d '[:space:]')"
+            [ -z "$l" ] && continue
+            if [[ "$l" =~ ^(python|c-cpp|javascript-typescript)$ ]]; then
+              langs+=("$l")
+            else
+              echo "::warning::Ignoring unsupported CodeQL language '$l' (valid: python, c-cpp, javascript-typescript)"
+            fi
+          done
+        else
+          if [ "$DETECT_PYTHON" = "true" ]; then langs+=("python"); fi
+          if [ "$DETECT_C_CPP" = "true" ]; then langs+=("c-cpp"); fi
+          if [ "$DETECT_JS_TS" = "true" ]; then langs+=("javascript-typescript"); fi
+        fi
+        if [ ${#langs[@]} -eq 0 ]; then
+          echo "matrix=[]" >> "$GITHUB_OUTPUT"
+          echo "has_codeql=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "matrix=$(printf '%s\n' "${langs[@]}" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+          echo "has_codeql=true" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -277,11 +277,15 @@ jobs:
           fi
 
       - id: codeql-matrix
+        env:
+          # Map the input to an env var instead of inlining the ${{ }} expression
+          # into the shell — avoids GitHub Actions expression/shell injection.
+          CODEQL_LANGUAGES: ${{ inputs.codeql-languages }}
         run: |
           langs=()
-          if [ -n "${{ inputs.codeql-languages }}" ]; then
+          if [ -n "$CODEQL_LANGUAGES" ]; then
             # Explicit allowlist overrides autodetection for CodeQL only (issue #227)
-            IFS=',' read -ra requested <<< "${{ inputs.codeql-languages }}"
+            IFS=',' read -ra requested <<< "$CODEQL_LANGUAGES"
             for l in "${requested[@]}"; do
               l="$(echo "$l" | tr -d '[:space:]')"
               [ -n "$l" ] && langs+=("$l")

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -116,6 +116,18 @@ on:
         required: false
         type: boolean
         default: false
+      codeql-languages:
+        description: >-
+          Comma-separated CodeQL language allowlist (e.g. "python" or
+          "python,javascript-typescript"). When set, this overrides the
+          filesystem autodetection for the CodeQL matrix ONLY, so a
+          Python/Cython repo whose only C/C++ is generated or a committed
+          test fixture isn't forced into a spurious c-cpp analysis whose
+          autobuild fails (issue #227). Valid values: python, c-cpp,
+          javascript-typescript. Empty (default) = autodetect from sources.
+        required: false
+        type: string
+        default: ''
       # --- Quality inputs ---
       fail-on-lint:
         description: "Fail on lint violations"
@@ -267,9 +279,18 @@ jobs:
       - id: codeql-matrix
         run: |
           langs=()
-          if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi
-          if [ "${{ steps.detect.outputs.c_cpp }}" = "true" ]; then langs+=("c-cpp"); fi
-          if [ "${{ steps.detect.outputs.js_ts }}" = "true" ]; then langs+=("javascript-typescript"); fi
+          if [ -n "${{ inputs.codeql-languages }}" ]; then
+            # Explicit allowlist overrides autodetection for CodeQL only (issue #227)
+            IFS=',' read -ra requested <<< "${{ inputs.codeql-languages }}"
+            for l in "${requested[@]}"; do
+              l="$(echo "$l" | tr -d '[:space:]')"
+              [ -n "$l" ] && langs+=("$l")
+            done
+          else
+            if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi
+            if [ "${{ steps.detect.outputs.c_cpp }}" = "true" ]; then langs+=("c-cpp"); fi
+            if [ "${{ steps.detect.outputs.js_ts }}" = "true" ]; then langs+=("javascript-typescript"); fi
+          fi
           if [ ${#langs[@]} -eq 0 ]; then
             echo "matrix=[]" >> "$GITHUB_OUTPUT"
             echo "has_codeql=false" >> "$GITHUB_OUTPUT"
@@ -601,7 +622,13 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v4
+          # c-cpp uses build-mode: none so a repo with no C/C++ build system
+          # (Cython-generated sources or a committed test fixture) isn't
+          # hard-failed by autobuild, which would cascade into a required CI
+          # failure (issue #227). Other languages keep the default build mode.
+          build-mode: ${{ matrix.language == 'c-cpp' && 'none' || '' }}
+      - if: matrix.language != 'c-cpp'
+        uses: github/codeql-action/autobuild@v4
       - uses: github/codeql-action/analyze@v4
         with:
           upload: false

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -288,7 +288,11 @@ jobs:
             IFS=',' read -ra requested <<< "$CODEQL_LANGUAGES"
             for l in "${requested[@]}"; do
               l="$(echo "$l" | tr -d '[:space:]')"
-              [ -n "$l" ] && langs+=("$l")
+              if [[ "$l" =~ ^(python|c-cpp|javascript-typescript)$ ]]; then
+                langs+=("$l")
+              elif [ -n "$l" ]; then
+                echo "::warning::Ignoring unsupported CodeQL language '$l' (valid: python, c-cpp, javascript-typescript)"
+              fi
             done
           else
             if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -276,36 +276,16 @@ jobs:
             echo "js_ts=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Shared composite action (referenced by pinned remote ref because a
+      # ./-relative local action would resolve against the CALLER's checkout
+      # in a reusable workflow, not this repo — issue #227).
       - id: codeql-matrix
-        env:
-          # Map the input to an env var instead of inlining the ${{ }} expression
-          # into the shell — avoids GitHub Actions expression/shell injection.
-          CODEQL_LANGUAGES: ${{ inputs.codeql-languages }}
-        run: |
-          langs=()
-          if [ -n "$CODEQL_LANGUAGES" ]; then
-            # Explicit allowlist overrides autodetection for CodeQL only (issue #227)
-            IFS=',' read -ra requested <<< "$CODEQL_LANGUAGES"
-            for l in "${requested[@]}"; do
-              l="$(echo "$l" | tr -d '[:space:]')"
-              if [[ "$l" =~ ^(python|c-cpp|javascript-typescript)$ ]]; then
-                langs+=("$l")
-              elif [ -n "$l" ]; then
-                echo "::warning::Ignoring unsupported CodeQL language '$l' (valid: python, c-cpp, javascript-typescript)"
-              fi
-            done
-          else
-            if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi
-            if [ "${{ steps.detect.outputs.c_cpp }}" = "true" ]; then langs+=("c-cpp"); fi
-            if [ "${{ steps.detect.outputs.js_ts }}" = "true" ]; then langs+=("javascript-typescript"); fi
-          fi
-          if [ ${#langs[@]} -eq 0 ]; then
-            echo "matrix=[]" >> "$GITHUB_OUTPUT"
-            echo "has_codeql=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "matrix=$(printf '%s\n' "${langs[@]}" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
-            echo "has_codeql=true" >> "$GITHUB_OUTPUT"
-          fi
+        uses: Claire-s-Monster/ci-framework/.github/actions/setup-codeql-matrix@main
+        with:
+          codeql-languages: ${{ inputs.codeql-languages }}
+          python: ${{ steps.detect.outputs.python }}
+          c_cpp: ${{ steps.detect.outputs.c_cpp }}
+          js_ts: ${{ steps.detect.outputs.js_ts }}
 
   hygiene:
     name: "🧹 Repository Hygiene"

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -148,36 +148,16 @@ jobs:
             echo "js_ts=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Shared composite action (referenced by pinned remote ref because a
+      # ./-relative local action would resolve against the CALLER's checkout
+      # in a reusable workflow, not this repo — issue #227).
       - id: codeql-matrix
-        env:
-          # Map the input to an env var instead of inlining the ${{ }} expression
-          # into the shell — avoids GitHub Actions expression/shell injection.
-          CODEQL_LANGUAGES: ${{ inputs.codeql-languages }}
-        run: |
-          langs=()
-          if [ -n "$CODEQL_LANGUAGES" ]; then
-            # Explicit allowlist overrides autodetection for CodeQL only (issue #227)
-            IFS=',' read -ra requested <<< "$CODEQL_LANGUAGES"
-            for l in "${requested[@]}"; do
-              l="$(echo "$l" | tr -d '[:space:]')"
-              if [[ "$l" =~ ^(python|c-cpp|javascript-typescript)$ ]]; then
-                langs+=("$l")
-              elif [ -n "$l" ]; then
-                echo "::warning::Ignoring unsupported CodeQL language '$l' (valid: python, c-cpp, javascript-typescript)"
-              fi
-            done
-          else
-            if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi
-            if [ "${{ steps.detect.outputs.c_cpp }}" = "true" ]; then langs+=("c-cpp"); fi
-            if [ "${{ steps.detect.outputs.js_ts }}" = "true" ]; then langs+=("javascript-typescript"); fi
-          fi
-          if [ ${#langs[@]} -eq 0 ]; then
-            echo "matrix=[]" >> "$GITHUB_OUTPUT"
-            echo "has_codeql=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "matrix=$(printf '%s\n' "${langs[@]}" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
-            echo "has_codeql=true" >> "$GITHUB_OUTPUT"
-          fi
+        uses: Claire-s-Monster/ci-framework/.github/actions/setup-codeql-matrix@main
+        with:
+          codeql-languages: ${{ inputs.codeql-languages }}
+          python: ${{ steps.detect.outputs.python }}
+          c_cpp: ${{ steps.detect.outputs.c_cpp }}
+          js_ts: ${{ steps.detect.outputs.js_ts }}
 
   python-dep-audit:
     name: "🐍 Python Dependency Audit (Pixi)"

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -160,7 +160,11 @@ jobs:
             IFS=',' read -ra requested <<< "$CODEQL_LANGUAGES"
             for l in "${requested[@]}"; do
               l="$(echo "$l" | tr -d '[:space:]')"
-              [ -n "$l" ] && langs+=("$l")
+              if [[ "$l" =~ ^(python|c-cpp|javascript-typescript)$ ]]; then
+                langs+=("$l")
+              elif [ -n "$l" ]; then
+                echo "::warning::Ignoring unsupported CodeQL language '$l' (valid: python, c-cpp, javascript-typescript)"
+              fi
             done
           else
             if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -149,11 +149,15 @@ jobs:
           fi
 
       - id: codeql-matrix
+        env:
+          # Map the input to an env var instead of inlining the ${{ }} expression
+          # into the shell — avoids GitHub Actions expression/shell injection.
+          CODEQL_LANGUAGES: ${{ inputs.codeql-languages }}
         run: |
           langs=()
-          if [ -n "${{ inputs.codeql-languages }}" ]; then
+          if [ -n "$CODEQL_LANGUAGES" ]; then
             # Explicit allowlist overrides autodetection for CodeQL only (issue #227)
-            IFS=',' read -ra requested <<< "${{ inputs.codeql-languages }}"
+            IFS=',' read -ra requested <<< "$CODEQL_LANGUAGES"
             for l in "${requested[@]}"; do
               l="$(echo "$l" | tr -d '[:space:]')"
               [ -n "$l" ] && langs+=("$l")

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -35,6 +35,17 @@ on:
         required: false
         type: string
         default: ''
+      codeql-languages:
+        description: >-
+          Comma-separated CodeQL language allowlist (e.g. "python"). When set,
+          overrides autodetection for the CodeQL matrix ONLY — unlike
+          `languages`, which restricts every security scan. Lets a caller keep
+          autodetect for dependency/secret scans while pinning CodeQL to
+          specific languages (issue #227). Valid values: python, c-cpp,
+          javascript-typescript. Empty (default) = autodetect from sources.
+        required: false
+        type: string
+        default: ''
       fail-on-cve:
         description: "Fail on known dependency CVEs"
         required: false
@@ -140,9 +151,18 @@ jobs:
       - id: codeql-matrix
         run: |
           langs=()
-          if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi
-          if [ "${{ steps.detect.outputs.c_cpp }}" = "true" ]; then langs+=("c-cpp"); fi
-          if [ "${{ steps.detect.outputs.js_ts }}" = "true" ]; then langs+=("javascript-typescript"); fi
+          if [ -n "${{ inputs.codeql-languages }}" ]; then
+            # Explicit allowlist overrides autodetection for CodeQL only (issue #227)
+            IFS=',' read -ra requested <<< "${{ inputs.codeql-languages }}"
+            for l in "${requested[@]}"; do
+              l="$(echo "$l" | tr -d '[:space:]')"
+              [ -n "$l" ] && langs+=("$l")
+            done
+          else
+            if [ "${{ steps.detect.outputs.python }}" = "true" ]; then langs+=("python"); fi
+            if [ "${{ steps.detect.outputs.c_cpp }}" = "true" ]; then langs+=("c-cpp"); fi
+            if [ "${{ steps.detect.outputs.js_ts }}" = "true" ]; then langs+=("javascript-typescript"); fi
+          fi
           if [ ${#langs[@]} -eq 0 ]; then
             echo "matrix=[]" >> "$GITHUB_OUTPUT"
             echo "has_codeql=false" >> "$GITHUB_OUTPUT"
@@ -263,7 +283,13 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v4
+          # c-cpp uses build-mode: none so a repo with no C/C++ build system
+          # (Cython-generated sources or a committed test fixture) isn't
+          # hard-failed by autobuild, which would cascade into a required CI
+          # failure (issue #227). Other languages keep the default build mode.
+          build-mode: ${{ matrix.language == 'c-cpp' && 'none' || '' }}
+      - if: matrix.language != 'c-cpp'
+        uses: github/codeql-action/autobuild@v4
       # upload: true uses the native code-scanning path so the aggregate `CodeQL`
       # check reports success instead of `neutral` (issue #222). The upload is
       # performed with CI_BOT_TOKEN (a PAT with the security_events scope), so the


### PR DESCRIPTION
## Summary

Fixes #227 — a Python/Cython repo enabling framework CodeQL is forced into a spurious `c-cpp` analysis (from a single committed `.cpp`, e.g. a test fixture) whose `autobuild` hard-fails, cascading into a **required** red `CI Success` check.

Root cause: in both `reusable-ci.yml` (`detect-changes`) and `reusable-security.yml` (`detect-languages`), the CodeQL language matrix is chosen purely from a filesystem `find` for `*.c`/`*.cpp`/`*.h`. `reusable-ci.yml` had **no** override at all; the failed `c-cpp` job sets `needs.checks.result` to `failure` (the caller's `ci-success` gate reads all jobs, not the filtered `summary`), so the required check goes red.

## Changes (both reusable workflows)

**Option 1 — `codeql-languages` allowlist input (scoped)**
- New optional string input `codeql-languages` (e.g. `"python"` or `"python,javascript-typescript"`).
- When set, it overrides autodetection for the **CodeQL matrix only** — it does NOT mutate the shared `detect` language booleans that other jobs consume. (In `reusable-security.yml` this is finer-grained than the existing broad `languages` input, which restricts every security scan.)

**Option 3 — harden the c-cpp leg**
- The `c-cpp` matrix leg now uses `build-mode: none` and skips `autobuild`, so a repo with no C/C++ build system is analyzed without a build instead of hard-failing. Other languages keep the default build mode.

## Usage for the reported case

```yaml
# caller ci.yml
with:
  codeql: true
  codeql-languages: python   # pin CodeQL to python; no spurious c-cpp leg
```

## Validation

- `actionlint -no-color` on both files: **PASS** (exit 0).
- Shell/YAML structure of the rewritten `codeql-matrix` steps confirmed balanced.

Refs #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)