### PR TITLE
fix(ci): skip Gemini AI review on dependabot pull_request runs

### DIFF
--- a/.github/workflows/reusable-gemini-ai.yml
+++ b/.github/workflows/reusable-gemini-ai.yml
@@ -50,7 +50,11 @@ permissions:
 
 jobs:
   pr-review:
-    if: inputs.enable-pr-review && github.event_name == 'pull_request'
+    # GitHub withholds repository secrets from pull_request-triggered runs
+    # authored by dependabot[bot] (same protection class as fork-PR secrets),
+    # so GEMINI_API_KEY is unavailable here regardless of repo config. Skip
+    # cleanly instead of failing.
+    if: inputs.enable-pr-review && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -153,7 +157,9 @@ jobs:
             });
 
   ci-analysis:
-    if: inputs.enable-ci-analysis && github.event_name == 'pull_request'
+    # See pr-review job: dependabot[bot]-authored pull_request runs have no
+    # access to repository secrets, so GEMINI_API_KEY is unavailable here.
+    if: inputs.enable-ci-analysis && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- `reusable-gemini-ai.yml`'s `pr-review` and `ci-analysis` jobs fail with `ValueError: No API key was provided` on every Dependabot version-bump PR (e.g. #234, #237, #238).
- Root cause: GitHub withholds repository secrets from `pull_request`-triggered workflow runs authored by `dependabot[bot]` — an intentional platform restriction (same protection class as fork-PR secret withholding), not a repo config gap. `GEMINI_API_KEY` is therefore never available to these jobs on Dependabot PRs, regardless of how the secret is configured.
- Fix: skip both jobs cleanly when `github.actor == 'dependabot[bot]'`, matching the existing convention already used in `dependabot-auto-merge.yml`, instead of routing around the restriction (e.g. via `pull_request_target`, which would reintroduce pwn-request risk for marginal value on auto-mergeable version bumps).
- `issue-triage` and `comprehensive-analysis` jobs are untouched — they trigger on different events (`issues`, `workflow_dispatch`) and aren't affected by this failure mode.
- Fixed at the reusable-workflow level so all consumers of `reusable-gemini-ai.yml` benefit, not just this repo's self-use wrapper.

## Test plan

- [ ] actionlint / YAML lint passes in CI on this PR
- [ ] Confirm `ai-analysis` shows as skipped (not failing) on the next Dependabot PR run
- [ ] Confirm `ai-analysis` still runs normally on non-Dependabot PRs
