### PR TITLE
fix(ci): key dependabot ai-analysis skip off PR author, not github.actor

### DIFF
--- a/.github/workflows/reusable-gemini-ai.yml
+++ b/.github/workflows/reusable-gemini-ai.yml
@@ -53,8 +53,10 @@ jobs:
     # GitHub withholds repository secrets from pull_request-triggered runs
     # authored by dependabot[bot] (same protection class as fork-PR secrets),
     # so GEMINI_API_KEY is unavailable here regardless of repo config. Skip
-    # cleanly instead of failing.
-    if: inputs.enable-pr-review && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # cleanly instead of failing. Use the PR author, not github.actor, since
+    # github.actor reflects whoever triggers this run (e.g. a manual rerun)
+    # and would otherwise defeat this check.
+    if: inputs.enable-pr-review && github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -159,7 +161,8 @@ jobs:
   ci-analysis:
     # See pr-review job: dependabot[bot]-authored pull_request runs have no
     # access to repository secrets, so GEMINI_API_KEY is unavailable here.
-    if: inputs.enable-ci-analysis && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Checked via the PR author since github.actor breaks on manual reruns.
+    if: inputs.enable-ci-analysis && github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Follow-up to #239, which added `github.actor != 'dependabot[bot]'` to skip `pr-review`/`ci-analysis` on Dependabot PRs.
- Verified via a live rerun of PR #234's failed jobs that this check is broken: `github.actor` reflects whoever triggers the *current* run, not the PR's author. A manual `gh run rerun --failed` runs under the triggering human/token's identity, so the guard silently passes and the job still fails with `No API key was provided` — confirmed in the job log, which explicitly shows `Secret source: Dependabot`, proving the secret restriction is tied to the PR's origin/branch, not to who triggered this particular run.
- Fix: use `github.event.pull_request.user.login != 'dependabot[bot]'` instead — checks the PR's actual author and stays stable across manual reruns.
- `issue-triage` and `comprehensive-analysis` untouched (different trigger events, unaffected).

## Test plan

- [ ] actionlint / YAML lint passes in CI on this PR
- [ ] After merge, manually rerun the failed jobs on PR #234/#237/#238 again and confirm they now show `skipped`
- [ ] Confirm `ai-analysis` still runs normally on non-Dependabot PRs, including on manual reruns
