### PR TITLE
fix(ci): bump pinned pixi CLI version to v0.74.0 (schema v7 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Set up Pixi"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           manifest-path: pyproject.toml
           cache: false
       - name: "Install Quality Dependencies"
@@ -70,7 +70,7 @@ jobs:
       - name: "Set up Pixi"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           manifest-path: pyproject.toml
           cache: false
       - name: "Install Security Dependencies"
@@ -107,7 +107,7 @@ jobs:
       - name: "Set up Pixi"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           manifest-path: pyproject.toml
           cache: false
       - name: "Install CI Dependencies"
@@ -131,7 +131,7 @@ jobs:
       - name: "Set up Pixi"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           manifest-path: pyproject.toml
           cache: false
       - name: "Install CI Dependencies"

--- a/.github/workflows/python-ci-template.yml.template
+++ b/.github/workflows/python-ci-template.yml.template
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 env:
-  PIXI_VERSION: v0.49.0
+  PIXI_VERSION: v0.74.0
 
 jobs:
   change-detection:

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -357,7 +357,7 @@ jobs:
       - name: "Setup PIXI Environment"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           cache: false
       - name: "Install Dependencies"
         working-directory: ${{ inputs.package-path }}
@@ -501,7 +501,7 @@ jobs:
       - name: "Setup PIXI Environment"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           cache: false
       - name: "Install Dependencies"
         working-directory: ${{ inputs.package-path }}
@@ -700,7 +700,7 @@ jobs:
       - name: "Setup PIXI Environment"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           cache: false
       - name: "Install Dependencies"
         working-directory: ${{ inputs.package-path }}
@@ -757,7 +757,7 @@ jobs:
       - name: "Setup PIXI Environment"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           cache: false
       - name: "Install Dependencies"
         working-directory: ${{ inputs.package-path }}
@@ -790,7 +790,7 @@ jobs:
       - name: "Setup PIXI Environment"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           cache: false
       - name: "Install Performance Environment"
         working-directory: ${{ inputs.package-path }}
@@ -820,7 +820,7 @@ jobs:
       - name: "Setup PIXI Environment"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           cache: false
       - name: "Install Dependencies"
         working-directory: ${{ inputs.package-path }}

--- a/.github/workflows/reusable-gemini-ai.yml
+++ b/.github/workflows/reusable-gemini-ai.yml
@@ -36,7 +36,7 @@ on:
         description: 'Pixi version to use'
         required: false
         type: string
-        default: 'v0.41.4'
+        default: 'v0.74.0'
     secrets:
       GEMINI_API_KEY:
         description: 'Google Gemini API key'

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -169,7 +169,7 @@ jobs:
       - name: "Setup PIXI Environment"
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.74.0
           cache: false
       - name: "Install Dependencies"
         run: pixi install -e ci || pixi install

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -48,7 +48,7 @@ permissions: read-all
 # STEP-LEVEL CONFIGURATION — Used in step run/with blocks
 # ============================================================================
 env:
-  PIXI_VERSION: 'v0.49.0'
+  PIXI_VERSION: 'v0.74.0'
   PIXI_ENVIRONMENT: 'ci'
   PACKAGE_PATH: '.'
   ALLOWED_LICENSES: 'MIT, Apache-2.0, BSD-3-Clause'

--- a/actions/change-detection/action.yml
+++ b/actions/change-detection/action.yml
@@ -143,7 +143,7 @@ runs:
     - name: Install pixi
       uses: prefix-dev/setup-pixi@v0.8.13
       with:
-        pixi-version: v0.49.0
+        pixi-version: v0.74.0
         cache: false
 
     - name: Cache Change Detection Dependencies

--- a/actions/cross-platform-validation/README.md
+++ b/actions/cross-platform-validation/README.md
@@ -106,7 +106,6 @@ jobs:
 | `test-commands` | Test commands to run (newline-separated) | No | `pixi run test\npixi run lint` |
 | `fail-fast` | Stop on first platform failure | No | `'false'` |
 | `timeout` | Timeout in minutes per platform | No | `'15'` |
-| `pixi-version` | Pixi version to use | No | `'v0.15.1'` |
 | `cache` | Enable pixi caching | No | `'false'` |
 | `platform-matrix` | Custom platform matrix JSON | No | `''` |
 | `pre-test-setup` | Commands before testing | No | `''` |

--- a/actions/cross-platform-validation/action.yml
+++ b/actions/cross-platform-validation/action.yml
@@ -39,11 +39,6 @@ inputs:
     required: false
     default: '15'
     
-  pixi-version:
-    description: 'Pixi version to use'
-    required: false
-    default: 'v0.15.1'
-    
   cache:
     description: 'Enable pixi caching (disabled for cross-platform to ensure fresh resolution)'
     required: false

--- a/actions/performance-benchmark/action.yml
+++ b/actions/performance-benchmark/action.yml
@@ -119,7 +119,7 @@ runs:
     - name: Install pixi
       uses: prefix-dev/setup-pixi@v0.8.13
       with:
-        pixi-version: v0.49.0
+        pixi-version: v0.74.0
         cache: false
 
     - name: Cache Performance Dependencies

--- a/actions/quality-gates/action.yml
+++ b/actions/quality-gates/action.yml
@@ -91,7 +91,7 @@ runs:
     - name: Install pixi
       uses: prefix-dev/setup-pixi@v0.8.13
       with:
-        pixi-version: v0.49.0
+        pixi-version: v0.74.0
         cache: false
 
     - name: Cache Quality Gates Dependencies

--- a/actions/security-scan/action.yml
+++ b/actions/security-scan/action.yml
@@ -150,7 +150,7 @@ runs:
     - name: Install pixi
       uses: prefix-dev/setup-pixi@v0.8.13
       with:
-        pixi-version: v0.49.0
+        pixi-version: v0.74.0
         cache: false
 
     - name: Install Docker (for Trivy)

--- a/actions/self-healing/action.yml
+++ b/actions/self-healing/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Install PIXI
       uses: prefix-dev/setup-pixi@v0.8.13
       with:
-        pixi-version: v0.49.0
+        pixi-version: v0.74.0
         cache: false
         
     - name: Install dependencies

--- a/docs/ci-workflow-guide.md
+++ b/docs/ci-workflow-guide.md
@@ -188,7 +188,7 @@ Add project-specific environment variables:
 
 ```yaml
 env:
-  PIXI_VERSION: v0.49.0
+  PIXI_VERSION: v0.74.0
   # Add your custom variables
   API_BASE_URL: https://api.example.com
   ENVIRONMENT: ci
@@ -209,7 +209,7 @@ env:
 - name: Setup Pixi
   uses: prefix-dev/setup-pixi@v0.8.11  # Use latest version
   with:
-    pixi-version: v0.49.0  # Use specific pixi version
+    pixi-version: v0.74.0  # Use specific pixi version
 ```
 
 #### 2. "No module named 'your_module'"

--- a/docs/examples/interactive/troubleshooting-guide.md
+++ b/docs/examples/interactive/troubleshooting-guide.md
@@ -332,7 +332,7 @@ def fast_function(items):
    - name: Install pixi
      uses: prefix-dev/setup-pixi@v0.8.11
      with:
-       pixi-version: v0.15.1
+       pixi-version: v0.74.0
    ```
 
 2. **Environment resolution errors**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,7 +45,7 @@ echo 'install-dev = "pip install -e ."' >> pyproject.toml
 - name: Setup Pixi
   uses: prefix-dev/setup-pixi@v0.8.11  # Use latest version
   with:
-    pixi-version: v0.49.0  # Use stable pixi version
+    pixi-version: v0.74.0  # Use stable pixi version
 ```
 
 **Alternative Solution** (Poetry):

--- a/framework/tests/workflows/test_ci_matrix_validation.py
+++ b/framework/tests/workflows/test_ci_matrix_validation.py
@@ -120,7 +120,7 @@ class TestCIMatrixValidation:
         # Verify environment variable is set
         env = ci_template_content.get("env", {})
         assert "PIXI_VERSION" in env, "PIXI_VERSION environment variable not set"
-        assert env["PIXI_VERSION"] == "v0.49.0", "Unexpected pixi version"
+        assert env["PIXI_VERSION"] == "v0.74.0", "Unexpected pixi version"
 
     def test_matrix_artifact_naming(self, ci_template_content):
         """Test that artifacts are properly named per matrix combination"""


### PR DESCRIPTION
## Summary

- Every workflow/action in this repo pinned the pixi **CLI** version (`pixi-version:` inputs / `PIXI_VERSION` env vars — distinct from the `prefix-dev/setup-pixi@vX.Y.Z` action wrapper tag) to `v0.49.0`, with stragglers at `v0.41.4` (`reusable-gemini-ai.yml`) and `v0.15.1` (a dead, unused `pixi-version` input in `cross-platform-validation/action.yml`).
- Pixi `v0.68.0` introduced `pixi.lock` schema v7; `v0.49.0` predates it, so any consumer with a schema-v7 lockfile fails against this framework's pinned CLI.
- Root cause of the staleness: `dependabot.yml`'s `github-actions` ecosystem automatically bumps the `prefix-dev/setup-pixi@vX.Y.Z` action tag, but has no mechanism to bump the separate `pixi-version:`/`PIXI_VERSION:` CLI string — so the actual CLI pin silently never advanced regardless of action-tag bumps landing.
- Action tags are intentionally left untouched here (Dependabot's job); only the CLI version strings are bumped, to `v0.74.0` (current latest stable as of 2026-07-28).

## Changes

- Bump `pixi-version`/`PIXI_VERSION` `v0.49.0` -> `v0.74.0` across `ci.yml`, `reusable-ci.yml` (6 sites), `reusable-security.yml`, `standalone-ci.yml`, `python-ci-template.yml.template`, 5 composite actions (`self-healing`, `security-scan`, `quality-gates`, `performance-benchmark`, `change-detection`), and docs (`ci-workflow-guide.md`, `troubleshooting.md`).
- Bump `reusable-gemini-ai.yml`'s `pixi-version` input default `v0.41.4` -> `v0.74.0`.
- Bump stray `docs/examples/interactive/troubleshooting-guide.md` example `v0.15.1` -> `v0.74.0`.
- Remove the dead/unused `pixi-version` input from `cross-platform-validation/action.yml` (never referenced anywhere in the file) and its corresponding README.md row.
- Update `test_ci_matrix_validation.py`'s hardcoded `PIXI_VERSION` assertion to match (was asserting the old `v0.49.0` literal) — verified passing locally.

## Test plan

- [x] `test_pixi_installation_cross_platform` passes locally with the updated assertion
- [ ] actionlint / YAML lint passes in CI on this PR
- [ ] Full CI suite green
