### PR TITLE
fix(ci): pin setup-codeql-matrix action ref to release tag instead of @main

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -278,9 +278,12 @@ jobs:
 
       # Shared composite action (referenced by pinned remote ref because a
       # ./-relative local action would resolve against the CALLER's checkout
-      # in a reusable workflow, not this repo — issue #227).
+      # in a reusable workflow, not this repo — issue #227). Pinned to a
+      # release tag rather than @main to avoid version drift for consumers
+      # pinned to an older workflow tag (issue #230); release-please keeps
+      # this ref in lockstep via the x-release-please-version marker.
       - id: codeql-matrix
-        uses: Claire-s-Monster/ci-framework/.github/actions/setup-codeql-matrix@main
+        uses: Claire-s-Monster/ci-framework/.github/actions/setup-codeql-matrix@v2.9.8 # x-release-please-version
         with:
           codeql-languages: ${{ inputs.codeql-languages }}
           python: ${{ steps.detect.outputs.python }}

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -150,9 +150,12 @@ jobs:
 
       # Shared composite action (referenced by pinned remote ref because a
       # ./-relative local action would resolve against the CALLER's checkout
-      # in a reusable workflow, not this repo — issue #227).
+      # in a reusable workflow, not this repo — issue #227). Pinned to a
+      # release tag rather than @main to avoid version drift for consumers
+      # pinned to an older workflow tag (issue #230); release-please keeps
+      # this ref in lockstep via the x-release-please-version marker.
       - id: codeql-matrix
-        uses: Claire-s-Monster/ci-framework/.github/actions/setup-codeql-matrix@main
+        uses: Claire-s-Monster/ci-framework/.github/actions/setup-codeql-matrix@v2.9.8 # x-release-please-version
         with:
           codeql-languages: ${{ inputs.codeql-languages }}
           python: ${{ steps.detect.outputs.python }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -23,5 +23,9 @@
         {"type": "revert", "section": "⏪ Reverts", "hidden": false}
       ]
     }
-  }
+  },
+  "extra-files": [
+    { "type": "generic", "path": ".github/workflows/reusable-ci.yml" },
+    { "type": "generic", "path": ".github/workflows/reusable-security.yml" }
+  ]
 }


### PR DESCRIPTION
## Problem

`setup-codeql-matrix` is referenced via a pinned remote ref (required inside a reusable workflow — a `./`-relative local action would resolve against the *caller's* checkout, not this repo). It was pointed at `@main`, so a consumer pinned to a released `reusable-ci.yml@vX.Y.Z` workflow tag silently got the composite action from whatever `main` happens to be at run time — behavioral drift underneath a version-pinned consumer. Flagged as a known caveat when the action was extracted (#227/#228), tracked as #230.

## Fix

- Pin both references (`reusable-ci.yml`, `reusable-security.yml`) to `@v2.9.8` (current release tag) instead of `@main`.
- Add a `# x-release-please-version` marker on each pinned line and wire `.release-please-config.json`'s `extra-files` (generic type) for both workflow files, so release-please bumps this ref in lockstep with the package version on every future release — no manual bump needed going forward.

Fixes #230