### PR TITLE
fix(ci): scope PYTHONNOUSERSITE=1 to the pytest step, not pixi activation

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -717,6 +717,8 @@ jobs:
           pixi run -e ${{ inputs.pixi-environment }} pip install -e . --no-deps
       - name: "Run Test Suite"
         working-directory: ${{ inputs.package-path }}
+        env:
+          PYTHONNOUSERSITE: "1" # ignore runner ~/.local so it cannot shadow pixi-pinned deps (issue #235)
         run: |
           pixi run -e ${{ inputs.pixi-environment }} test
 
@@ -774,6 +776,8 @@ jobs:
           pixi run -e ${{ inputs.pixi-environment }} pip install -e . --no-deps
       - name: "Run Test Suite (with PostgreSQL)"
         working-directory: ${{ inputs.package-path }}
+        env:
+          PYTHONNOUSERSITE: "1" # ignore runner ~/.local so it cannot shadow pixi-pinned deps (issue #235)
         run: |
           pixi run -e ${{ inputs.pixi-environment }} test
 

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -249,6 +249,8 @@ jobs:
           pixi run -e ${{ env.PIXI_ENVIRONMENT }} pip install -e . --no-deps
       - name: "Run Test Suite"
         working-directory: ${{ env.PACKAGE_PATH }}
+        env:
+          PYTHONNOUSERSITE: "1" # ignore runner ~/.local so it cannot shadow pixi-pinned deps (issue #235)
         run: |
           pixi run -e ${{ env.PIXI_ENVIRONMENT }} test
 

--- a/templates/pyproject-tiered-template.toml
+++ b/templates/pyproject-tiered-template.toml
@@ -93,10 +93,6 @@ dev = {features = ["quality", "quality-extended", "quality-ci", "dev-specialized
 # CI environment (quality + CI reporting)
 ci = {features = ["quality", "quality-ci"], solve-group = "default"}
 
-# Ensure proper environment isolation
-[tool.pixi.activation]
-env = { PYTHONNOUSERSITE = "1" }
-
 [tool.pixi.tasks]
 # ===== TIER 1: CORE DEVELOPMENT TASKS (ESSENTIAL) =====
 # Installation & Setup


### PR DESCRIPTION
## Problem

Consumers using this framework's reusable test workflows can intermittently fail because the GitHub Actions runner's user-site (`~/.local`) packages shadow pixi-pinned dependency versions at pytest runtime — e.g. a stray `aiohttp>=3.12` in `~/.local` resolving ahead of the pixi-pinned `aiohttp 3.11.18`, breaking `aioresponses` mocks (`TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'`). Runner-pool nondeterministic, not caused by the consumer's diff. Tracked as #235.

`templates/pyproject-tiered-template.toml` previously set `PYTHONNOUSERSITE=1` via `[tool.pixi.activation]`, which applies job-wide to every pixi task — including the separate `pip install -e .` step, which it breaks. This is the anti-pattern the issue explicitly warns against.

## Fix

- Remove the `[tool.pixi.activation]` block from `templates/pyproject-tiered-template.toml`.
- Add `PYTHONNOUSERSITE: "1"` as a step-level `env:` scoped to only the pytest-running "Run Test Suite" steps:
  - `reusable-ci.yml`: `test` job and `test-postgres` job (job-level `POSTGRES_DSN` env left untouched — step-level env is additive)
  - `standalone-ci.yml`: `test` job
- Left performance/benchmark pytest invocations untouched (out of scope for this issue).

Fixes #235